### PR TITLE
Lazily import pandas to speedup non-pandas use

### DIFF
--- a/tabledata/_core.py
+++ b/tabledata/_core.py
@@ -17,14 +17,6 @@ from ._converter import to_value_matrix
 from ._logger import logger
 
 
-try:
-    from pandas import DataFrame
-
-    INSTALLED_PANDAS = True
-except ImportError:
-    INSTALLED_PANDAS = False
-
-
 class TableData:
     """
     Class to represent a table data structure.
@@ -428,7 +420,9 @@ class TableData:
             - `pandas <https://pandas.pydata.org/>`__
         """
 
-        if not INSTALLED_PANDAS:
+        try:
+            from pandas import DataFrame
+        except ImportError:
             raise RuntimeError("required 'pandas' package to execute as_dataframe method")
 
         dataframe = DataFrame(self.value_matrix)


### PR DESCRIPTION
I'm using pytablewriter in some CLIs, and noticed they were sometimes slow so I profiled it.

Here's how to use `python -X importtime` and tuna to identify bottlenecks: https://medium.com/alan/how-we-improved-our-python-backend-start-up-time-2c33cd4873c8

For example with this test script:

```python
from pytablewriter import MarkdownTableWriter

def main():
    writer = MarkdownTableWriter(
        table_name="example_table",
        headers=["int", "float", "str", "bool", "mix", "time"],
        value_matrix=[
            [0,   0.1,      "hoge", True,   0,      "2017-01-01 03:04:05+0900"],
            [2,   "-2.23",  "foo",  False,  None,   "2017-12-23 45:01:23+0900"],
            [3,   0,        "bar",  "true",  "inf", "2017-03-03 33:44:55+0900"],
            [-10, -9.9,     "",     "FALSE", "nan", "2017-01-01 00:00:00+0900"],
        ],
    )
    return writer.dumps()
```

Then run:

```
python -m pip install tuna
python -X importtime -c "import pandastest; pandastest.main()" 2> pandastest-master.log
tuna pandastest-master.log
```

Shows most of the import time comes from pandas:

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/218853317-cf33697a-3a73-40f4-bcc1-75a8643dfe26.png">
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/218853418-610117a8-858f-4284-b5e2-cbea587e05c2.png">

It takes almost half a second to import pandas, 78.1% of the total 0.63s time.

This is not surprising, pandas and its dependency NumPy are big libraries.

However with this PR, if we lazily import pandas, that is, only import it when needed, we get a big speedup for all the non-pandas use cases, which covers a lot of pytablewriter's formats:

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/218854076-18c4bdb9-86fe-4ec7-831c-e935fafd8087.png">

Now it only takes 0.164s for the whole program, a huge improvement over the 0.63s before, and very noticeable on the command line.

Another quick before and after comparison:

```console
$ time python pandastest.py
python3 pandastest.py  0.95s user 2.02s system 432% cpu 0.687 total
$ time python pandastest.py
python3 pandastest.py  0.10s user 0.03s system 57% cpu 0.223 total
```